### PR TITLE
Bugfixes and updates to AWS SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-.idea/libraries
-.idea/tasks.xml
-.idea/workspace.xml
+.idea/
+*.iml
 target
 pom.xml.releaseBackup
 release.properties

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,5 +1,3 @@
 <component name="CopyrightManager">
-  <settings default="Apache License, Version 2.0">
-    <module2copyright />
-  </settings>
+  <settings default="Apache License, Version 2.0" />
 </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,8 +10,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>
-

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 This project is a [Maven Wagon][wagon] for [Amazon S3][s3].  In order to to publish artifacts to an S3 bucket, the user (as identified by their access key) must be listed as an owner on the bucket.
 
 ## Why this fork?
-This fork's enhancement is the ability to customize the AWS credentials 
-provider chain that is used to resolve credentials for the S3 bucket that hosts
-the Maven artifacts you deploy. The upstream version uses a default provider 
-chain that includes an `InstanceProfileCredentialsProvider` that, in my 
-opinion, just takes too darn long to realize it's not going to be able to 
-resolve any credentials and should give up.
+
+- Uses a more recent version of the AWS SDK (and only depends on the S3 portion of the SDK)
+- Allows customization of the AWS credentials provider chain
+- By default it uses the DefaultAWSCredentialsProviderChain built in to the S3 SDK.
+- Omits S3 calls for creating directories (unnecessary in S3)
+- Fixes https://github.com/spring-projects/aws-maven/issues/40
 
 ## Usage
 To publish Maven artifacts to S3 a build extension must be defined in a project's `pom.xml`.  The latest version of the wagon can be found in the `mvn-repo` branch of this repository.
@@ -101,6 +101,7 @@ tokens:
 
  - `EnvironmentVariable` - use an (EnvironmentVariableCredentialsProvider)[http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/EnvironmentVariableCredentialsProvider.html] that checks `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY` environment variables
  - `SystemProperties` - use a (SystemPropertiesCredentialsProvider)[http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/SystemPropertiesCredentialsProvider.html] that checks the `aws.accessKeyId` and `aws.secretKey` Java system properties
+ - `Profile` - use an (ProfileCredentialsProvider)[http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/profile/ProfileCredentialsProvider.html]
  - `InstanceProfile` - use an (InstanceProfileCredentialsProvider)[http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/InstanceProfileCredentialsProvider.html] that tries to load credentials from the Amazon EC2 Instance Metadata Service
  - `AuthenticationInfo` - use an `org.springframework.build.aws.maven.AuthenticationInfoAWSCredentialsProvider` that gets credentials from the `<server>` username and password settings from `~/.m2/settings.xml`
 

--- a/aws-maven.iml
+++ b/aws-maven.iml
@@ -12,24 +12,29 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: joda-time:joda-time:2.3" level="project" />
     <orderEntry type="library" name="Maven: ch.qos.logback:logback-classic:1.1.1" level="project" />
     <orderEntry type="library" name="Maven: ch.qos.logback:logback-core:1.1.1" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.6" level="project" />
-    <orderEntry type="library" name="Maven: com.amazonaws:aws-java-sdk:1.7.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.2" level="project" />
-    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.3" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.1.1" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.1.1" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.1.1" level="project" />
-    <orderEntry type="library" name="Maven: joda-time:joda-time:2.3" level="project" />
+    <orderEntry type="library" name="Maven: com.amazonaws:aws-java-sdk-s3:1.11.39" level="project" />
+    <orderEntry type="library" name="Maven: com.amazonaws:aws-java-sdk-kms:1.11.39" level="project" />
+    <orderEntry type="library" name="Maven: com.amazonaws:aws-java-sdk-core:1.11.39" level="project" />
+    <orderEntry type="library" name="Maven: com.amazonaws:jmespath-java:1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.5.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.4" level="project" />
+    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.9" level="project" />
+    <orderEntry type="library" name="Maven: software.amazon.ion:ion-java:1.0.0" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.6.6" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.6.0" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.6.6" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.6" level="project" />
+    <orderEntry type="library" name="Maven: joda-time:joda-time:2.8.1" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:jcl-over-slf4j:1.7.6" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven.wagon:wagon-provider-api:2.6" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.plexus:plexus-utils:3.0.8" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:1.9.5" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.slf4j:jcl-over-slf4j:1.7.6" level="project" />
   </component>
 </module>
-

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<description>Standard Maven wagon support for s3:// urls</description>
 
 	<properties>
-		<amazonaws.version>1.7.1</amazonaws.version>
+		<amazonaws.version>1.11.39</amazonaws.version>
 		<junit.version>4.11</junit.version>
 		<logback.version>1.1.1</logback.version>
 		<mockito.version>1.9.5</mockito.version>
@@ -34,31 +34,26 @@
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
+			<artifactId>aws-java-sdk-s3</artifactId>
 			<version>${amazonaws.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
-				<exclusion>
-					<groupId>javax.mail</groupId>
-					<artifactId>mail</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>stax</groupId>
-					<artifactId>stax-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>stax</groupId>
-					<artifactId>stax</artifactId>
-				</exclusion>
-			 <exclusion>
-			  <artifactId>joda-time</artifactId>
-			  <groupId>joda-time</groupId>
-			 </exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -76,16 +71,6 @@
 			<artifactId>mockito-core</artifactId>
 			<version>${mockito.version}</version>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
-			<version>${slf4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/springframework/build/aws/maven/AbstractWagon.java
+++ b/src/main/java/org/springframework/build/aws/maven/AbstractWagon.java
@@ -16,6 +16,9 @@
 
 package org.springframework.build.aws.maven;
 
+import java.io.File;
+import java.util.List;
+
 import org.apache.maven.wagon.ConnectionException;
 import org.apache.maven.wagon.ResourceDoesNotExistException;
 import org.apache.maven.wagon.TransferFailedException;
@@ -30,9 +33,6 @@ import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.proxy.ProxyInfoProvider;
 import org.apache.maven.wagon.repository.Repository;
 import org.apache.maven.wagon.resource.Resource;
-
-import java.io.File;
-import java.util.List;
 
 abstract class AbstractWagon implements Wagon {
 
@@ -216,6 +216,14 @@ abstract class AbstractWagon implements Wagon {
         // Nothing to do here (never called by the wagon manager)
     }
 
+    /**
+     *
+     * @param source
+     * @param destination should not begin with "/"
+     * @throws TransferFailedException
+     * @throws ResourceDoesNotExistException
+     * @throws AuthorizationException
+     */
     @Override
     public final void put(File source, String destination) throws TransferFailedException,
             ResourceDoesNotExistException, AuthorizationException {
@@ -239,7 +247,18 @@ abstract class AbstractWagon implements Wagon {
         File[] files = sourceDirectory.listFiles();
         if (files != null) {
             for (File f : files) {
-                put(f, destinationDirectory + "/" + f.getName());
+                String destinationPrefix;
+                if (destinationDirectory.equals("./")) {
+                    destinationPrefix = "";
+                } else {
+                    destinationPrefix = destinationDirectory + "/";
+                }
+
+                if (f.isFile()) {
+                    put(f, destinationPrefix + f.getName());
+                } else if (f.isDirectory()) {
+                    putDirectory(f, destinationPrefix + f.getName());
+                }
             }
         }
     }

--- a/src/main/java/org/springframework/build/aws/maven/S3Utils.java
+++ b/src/main/java/org/springframework/build/aws/maven/S3Utils.java
@@ -30,6 +30,11 @@ final class S3Utils {
         return repository.getHost();
     }
 
+    /**
+     *
+     * @param repository
+     * @return a string representation of the basedir, if non-empty always ending in '/'
+     */
     static String getBaseDirectory(Repository repository) {
         StringBuilder sb = new StringBuilder(repository.getBasedir()).deleteCharAt(0);
 


### PR DESCRIPTION
- Fixed uploads being prefixed with "./"
- Fixed https://github.com/spring-projects/aws-maven/issues/40 (caused by the code trying to upload a directory as if it was a file)
- DefaultAWSCredentialsProviderChain is now the default (enables profile based authentication out-of-the-box)
- Added support for configuring use of ProfileCredentialsProvider
- Removed unnecessary S3 calls for creating directories
- Updated to latest AWS SDK
- No longer depending on entire AWS SDK, only the S3 SDK
- Removed IntelliJ-specific files
